### PR TITLE
Fix regex used to parse Gemini output

### DIFF
--- a/Automated_Pitch_Deck_Generator.ipynb
+++ b/Automated_Pitch_Deck_Generator.ipynb
@@ -504,7 +504,7 @@
             "description": "",
             "description_tooltip": null,
             "layout": "IPY_MODEL_24872e1c582146948548eb9f7362dd4f",
-            "placeholder": "​",
+            "placeholder": "\u200b",
             "style": "IPY_MODEL_f2ee6402dbce4f7c90fc5afced32c2df",
             "value": "<h3>Company Overview</h3>"
           }
@@ -1115,7 +1115,7 @@
           "output_type": "display_data",
           "data": {
             "text/plain": [
-              "Dropdown(description='Industry:', options=('Technology', 'Healthcare', 'Finance', 'Retail', 'Other'), value='T…"
+              "Dropdown(description='Industry:', options=('Technology', 'Healthcare', 'Finance', 'Retail', 'Other'), value='T\u2026"
             ],
             "application/vnd.jupyter.widget-view+json": {
               "version_major": 2,
@@ -1353,7 +1353,7 @@
         "    \"\"\"\n",
         "    # This regex looks for a section name ending with a colon, and captures everything until the next section starts\n",
         "    pattern = re.compile(\n",
-        "        r'(?P<section>[A-Za-z ]+):\\s*(?P<content>.*?)(?=\\n[A-Za-z ]+:|$)',\n",
+        "        r'(?P<section>[^:\\n]+):\\s*(?P<content>.*?)(?=\\n[^:\\n]+:|$)',\n",
         "        re.DOTALL\n",
         "    )\n",
         "\n",
@@ -1361,6 +1361,7 @@
         "    parsed_data = {}\n",
         "    for match in sections:\n",
         "        section = match.group('section').strip()\n",
+        "        section = re.sub(r'[\\*]+$', '', section).strip()\n",
         "        content = match.group('content').strip()\n",
         "        parsed_data[section] = content\n",
         "    return parsed_data\n",
@@ -1759,7 +1760,7 @@
           "output_type": "display_data",
           "data": {
             "text/plain": [
-              "VBox(children=(HTML(value='<h3>Company Overview</h3>'), Textarea(value=\"**\\n\\nGlaxoSmithKline plc (GSK) is a g…"
+              "VBox(children=(HTML(value='<h3>Company Overview</h3>'), Textarea(value=\"**\\n\\nGlaxoSmithKline plc (GSK) is a g\u2026"
             ],
             "application/vnd.jupyter.widget-view+json": {
               "version_major": 2,
@@ -1773,7 +1774,7 @@
           "output_type": "display_data",
           "data": {
             "text/plain": [
-              "Button(button_style='success', description='Update Insights', style=ButtonStyle(), tooltip='Click to update th…"
+              "Button(button_style='success', description='Update Insights', style=ButtonStyle(), tooltip='Click to update th\u2026"
             ],
             "application/vnd.jupyter.widget-view+json": {
               "version_major": 2,


### PR DESCRIPTION
## Summary
- robustify regex in `parse_llm_output`
- strip trailing asterisks from section headings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684013b52b1083318d8db4a8fdadd2a3